### PR TITLE
Deprecated esc to exit the game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Terminal Wordle
+
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/Alvaroalonsobabbel/wordle) ![Test](https://github.com/Alvaroalonsobabbel/wordle/actions/workflows/test.yml/badge.svg) ![Latest Release](https://img.shields.io/github/v/release/Alvaroalonsobabbel/wordle?color=blue&label=Latest%20Release)
 
 Play the NYT daily Wordle from the comfort of your terminal!
@@ -20,7 +21,7 @@ curl -sSL https://raw.githubusercontent.com/Alvaroalonsobabbel/wordle/main/bin/i
 ```
 
 - You'll be required to enter your admin password.
-- You might be required to allow the program to run in the *System Settings - Privavacy & Security* tab.
+- You might be required to allow the program to run in the _System Settings - Privavacy & Security_ tab.
 
 ### Compiling the binary yourself
 
@@ -36,23 +37,26 @@ You can check the official Wordle rules [here](https://www.nytimes.com/2023/08/0
 1. Start Wordle by running `wordle` in your Terminal.
 2. Have fun!
 
-You can quit the game at any time by pressing `Esc` or `Ctrl C`
+You can quit the game at any time by pressing `Ctrl C`
 
 Status is held every time you quit the game or the game ends. The status will be automatically cleared when there is a new Wordle available or by manually by using the `-rmstatus` flag.
 
 ## Options
 
 Enables Worlde's hard mode.
-```
+
+```bash
 wordle -hard
 ```
 
 Prints current version.
-```
+
+```bash
 wordle -version
 ```
 
 Removes the status file.
-```
+
+```bash
 wordle -rmstatus
 ```

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -12,14 +12,13 @@ import (
 	"github.com/Alvaroalonsobabbel/wordle/pkg/wordle"
 )
 
-const VERSION = "v0.2.0"
+const VERSION = "v0.2.1"
 
 const (
 	// Relevant unicode characters to control the game.
 	enter     = 13
 	backspace = 127
 	ctrlC     = 3
-	esc       = 27
 
 	// Accepted characters regex.
 	okRegex = `^[A-Z]$`
@@ -145,8 +144,8 @@ func (t *terminal) read() bool {
 		log.Fatalf("Error reading input: %v", err)
 	}
 
-	// Ctrl-C or Esc exits the game
-	if t.buf[0] == ctrlC || t.buf[0] == esc {
+	// Ctrl-C exits the game
+	if t.buf[0] == ctrlC {
 		return true
 	}
 

--- a/pkg/terminal/terminal_test.go
+++ b/pkg/terminal/terminal_test.go
@@ -27,7 +27,6 @@ func TestRead(t *testing.T) {
 		wantExit bool
 	}{
 		{"ctrl-c exits the game", []byte{ctrlC}, true},
-		{"esc exits the game", []byte{esc}, true},
 		{"'A' does not exits the game", []byte{'A'}, false},
 	}
 


### PR DESCRIPTION
Esc key is ignored and doesn't exit the game anymore.
Updaated documentation to reflect this.