### PR TITLE
Updated error message buffer

### DIFF
--- a/terminal/render.go
+++ b/terminal/render.go
@@ -67,12 +67,14 @@ func (r *render) rmLastErr() {
 }
 
 func (r *render) printErrQ() {
-	for i := range len(r.errQ) + 1 {
+	for i := range 6 {
 		fmt.Fprintf(r.w, "\033[%d;28H\033[K", i+errOffset)
 	}
 
 	for i, log := range r.errQ {
-		fmt.Fprintf(r.w, "\033[%d;28H\x1b[3m\x1b[30m\x1b[47m %s \x1b[0m", i+errOffset, log)
+		if i < 6 {
+			fmt.Fprintf(r.w, "\033[%d;28H\x1b[3m\x1b[30m\x1b[47m %s \x1b[0m", i+errOffset, log)
+		}
 	}
 }
 

--- a/terminal/render_test.go
+++ b/terminal/render_test.go
@@ -32,7 +32,7 @@ func TestRender(t *testing.T) {
 
 		render.err("123")
 		render.wg.Wait()
-		assert.Equal(t, "\x1b[3;28H\x1b[K\x1b[4;28H\x1b[K\x1b[3;28H\x1b[3m\x1b[30m\x1b[47m 123 \x1b[0m\x1b[3;28H\x1b[K", buf.String())
+		assert.Equal(t, "\x1b[3;28H\x1b[K\x1b[4;28H\x1b[K\x1b[5;28H\x1b[K\x1b[6;28H\x1b[K\x1b[7;28H\x1b[K\x1b[8;28H\x1b[K\x1b[3;28H\x1b[3m\x1b[30m\x1b[47m 123 \x1b[0m\x1b[3;28H\x1b[K\x1b[4;28H\x1b[K\x1b[5;28H\x1b[K\x1b[6;28H\x1b[K\x1b[7;28H\x1b[K\x1b[8;28H\x1b[K", buf.String())
 	})
 
 	t.Run("prints str to w", func(t *testing.T) {


### PR DESCRIPTION
Error message display is now capped to 6 errors to prevent multiple errors reaching the keyboard area.